### PR TITLE
Add configurable native worktree workspace mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A [herdr](https://herdr.dev) plugin for switching, creating, and removing git
 worktrees through [worktrunk](https://github.com/max-sixty/worktrunk). Pick (or
-type) a branch in an fzf picker and the worktree opens as a herdr tab — with
-worktrunk's hooks running along the way.
+type) a branch in an fzf picker and open the worktree as a herdr tab or a native
+worktree workspace — with worktrunk's hooks running along the way.
 
 ## Why this plugin
 
@@ -17,8 +17,8 @@ have no hook system.
 
 Rather than reimplement hooks inside herdr, this plugin wires worktrunk's `wt`
 into herdr: you get worktrunk's hook-driven workflow (plus its niceties — base
-branch selection, PR shortcuts, live preview) while the resulting worktree opens
-as a herdr tab in your current workspace.
+branch selection, PR shortcuts, live preview) while choosing whether the
+resulting worktree opens as a tab or as a native linked-worktree workspace.
 
 ## What it does
 
@@ -26,13 +26,41 @@ Two workspace actions:
 
 - **Worktree: switch / create** — opens an fzf picker over your worktree
   branches. Press `Enter` on a match to switch to it, or type a new name and
-  press `Enter` to create it. The worktree opens in a new herdr tab where `wt`
-  runs, so worktrunk's create hooks execute in the pane you land in.
+  press `Enter` to create it. Worktrunk's lifecycle hooks run in either
+  presentation mode, and the checkout opens as a tab or a native worktree
+  workspace according to plugin configuration.
 - **Worktree: remove** — opens an fzf picker over removable worktrees
   (everything except the main checkout). Pick one; worktrunk prompts for
   confirmation and gates unmerged branches / untracked files itself, then
-  removes it. Any herdr panes left sitting inside the deleted worktree are
-  closed automatically.
+  removes it. The native workspace or any legacy tab panes associated with the
+  deleted worktree are closed automatically.
+
+## Worktree presentation
+
+The plugin keeps its original tab-based behavior by default. To organize
+worktrees the same way as herdr's built-in worktree support, set `open_mode` to
+`"workspace"` in the plugin's managed configuration directory:
+
+```bash
+config_dir=$(herdr plugin config-dir worktrunk)
+mkdir -p "$config_dir"
+${EDITOR:-vi} "$config_dir/config.toml"
+```
+
+```toml
+open_mode = "workspace"
+```
+
+Supported values:
+
+- `open_mode = "tab"` — open a new tab in the current workspace and run `wt`
+  there. This is the default and preserves the original plugin behavior.
+- `open_mode = "workspace"` — let Worktrunk create or switch the checkout and
+  run its hooks, then register that checkout with `herdr worktree open`. Herdr
+  displays it as a nested worktree workspace in the sidebar.
+
+The config file is read each time the picker runs, so changing the mode does not
+require reinstalling or reloading the plugin.
 
 ## Requirements
 
@@ -106,11 +134,13 @@ herdr server reload-config
 
 ## Development
 
-The plugin is just a manifest plus two bash scripts:
+The plugin is a manifest plus small bash scripts:
 
 - `herdr-plugin.toml` — actions and panes
+- `config.sh` — worktree presentation configuration
 - `picker.sh` — the switch / create picker
 - `remove.sh` — the remove picker + orphaned-pane cleanup
+- `tests/config_test.sh` — configuration parser checks
 
 herdr caches the manifest when a plugin is linked, so after editing
 `herdr-plugin.toml` you must relink for changes to take effect:
@@ -119,8 +149,7 @@ herdr caches the manifest when a plugin is linked, so after editing
 herdr plugin unlink worktrunk && herdr plugin link "$PWD"
 ```
 
-Edits to `picker.sh` / `remove.sh` are picked up on the next run — no relink
-needed.
+Edits to the bash scripts are picked up on the next run — no relink needed.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ Two workspace actions:
 
 ## Worktree presentation
 
-The plugin keeps its original tab-based behavior by default. To organize
-worktrees the same way as herdr's built-in worktree support, set `open_mode` to
-`"workspace"` in the plugin's managed configuration directory:
+By default the plugin organizes worktrees the same way as herdr's built-in
+worktree support: each checkout becomes a nested worktree workspace in the
+sidebar. To restore the original tab-based behavior, set `open_mode` to `"tab"`
+in the plugin's managed configuration directory:
 
 ```bash
 config_dir=$(herdr plugin config-dir worktrunk)
@@ -48,16 +49,16 @@ ${EDITOR:-vi} "$config_dir/config.toml"
 ```
 
 ```toml
-open_mode = "workspace"
+open_mode = "tab"
 ```
 
 Supported values:
 
-- `open_mode = "tab"` — open a new tab in the current workspace and run `wt`
-  there. This is the default and preserves the original plugin behavior.
 - `open_mode = "workspace"` — let Worktrunk create or switch the checkout and
   run its hooks, then register that checkout with `herdr worktree open`. Herdr
-  displays it as a nested worktree workspace in the sidebar.
+  displays it as a nested worktree workspace in the sidebar. This is the default.
+- `open_mode = "tab"` — open a new tab in the current workspace and run `wt`
+  there. This preserves the original plugin behavior.
 
 The config file is read each time the picker runs, so changing the mode does not
 require reinstalling or reloading the plugin.
@@ -65,7 +66,7 @@ require reinstalling or reloading the plugin.
 ## Requirements
 
 - [**herdr**](https://herdr.dev) ≥ 0.7.0
-- [**worktrunk**](https://github.com/max-sixty/worktrunk) — the `wt` CLI on your `PATH`
+- [**worktrunk**](https://github.com/max-sixty/worktrunk) ≥ 0.60.0 — the `wt` CLI on your `PATH`
 - **fzf** — the interactive picker
 - **jq** — JSON parsing
 - **bash** — the scripts run with `/bin/bash`

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Print the configured worktree presentation mode. The original tab-based mode
+# remains the default so existing installations keep their current behavior.
+worktrunk_open_mode() {
+  local config_file mode
+
+  if [[ -z ${HERDR_PLUGIN_CONFIG_DIR:-} ]]; then
+    printf '%s\n' tab
+    return
+  fi
+
+  config_file="$HERDR_PLUGIN_CONFIG_DIR/config.toml"
+  if [[ ! -f $config_file ]]; then
+    printf '%s\n' tab
+    return
+  fi
+
+  mode=$(sed -nE \
+    's/^[[:space:]]*open_mode[[:space:]]*=[[:space:]]*"([^"]+)"[[:space:]]*(#.*)?$/\1/p' \
+    "$config_file" | tail -n1)
+
+  case "$mode" in
+    ""|tab)
+      printf '%s\n' tab
+      ;;
+    workspace)
+      printf '%s\n' workspace
+      ;;
+    *)
+      printf '\033[33mWarning:\033[0m unsupported open_mode %q; using tab\n' "$mode" >&2
+      printf '%s\n' tab
+      ;;
+  esac
+}

--- a/config.sh
+++ b/config.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
-# Print the configured worktree presentation mode. The original tab-based mode
-# remains the default so existing installations keep their current behavior.
+# Print the configured worktree presentation mode. Native workspace mode is the
+# default; set open_mode = "tab" to keep the original tab-based behavior.
 worktrunk_open_mode() {
   local config_file mode
 
   if [[ -z ${HERDR_PLUGIN_CONFIG_DIR:-} ]]; then
-    printf '%s\n' tab
+    printf '%s\n' workspace
     return
   fi
 
   config_file="$HERDR_PLUGIN_CONFIG_DIR/config.toml"
   if [[ ! -f $config_file ]]; then
-    printf '%s\n' tab
+    printf '%s\n' workspace
     return
   fi
 
@@ -21,15 +21,15 @@ worktrunk_open_mode() {
     "$config_file" | tail -n1)
 
   case "$mode" in
-    ""|tab)
-      printf '%s\n' tab
-      ;;
-    workspace)
+    ""|workspace)
       printf '%s\n' workspace
       ;;
-    *)
-      printf '\033[33mWarning:\033[0m unsupported open_mode %q; using tab\n' "$mode" >&2
+    tab)
       printf '%s\n' tab
+      ;;
+    *)
+      printf '\033[33mWarning:\033[0m unsupported open_mode %q; using workspace\n' "$mode" >&2
+      printf '%s\n' workspace
       ;;
   esac
 }

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -22,8 +22,8 @@ title = "Worktree: remove"
 contexts = ["workspace"]
 command = ["bash", "-c", "cwd=$(jq -r '.workspace_cwd // .focused_pane_cwd' <<<\"$HERDR_PLUGIN_CONTEXT_JSON\"); exec \"$HERDR_BIN_PATH\" plugin pane open --plugin \"$HERDR_PLUGIN_ID\" --entrypoint remover --placement split --direction down --cwd \"$cwd\" --focus"]
 
-# Both panes run as plain bash. picker.sh runs `wt` in a fresh tab's shell (so
-# worktrunk's hooks and cd happen there); remove.sh runs the `wt` binary in-pane.
+# Both panes run as plain bash. Depending on plugin config, picker.sh opens the
+# checkout in a tab or registers it as a native herdr worktree workspace.
 [[panes]]
 id = "picker"
 title = "Worktrunk"

--- a/picker.sh
+++ b/picker.sh
@@ -23,21 +23,60 @@ else
 fi
 [[ -z $name ]] && exit 0
 
+plugin_root=${HERDR_PLUGIN_ROOT:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)}
+# shellcheck source=./config.sh
+source "$plugin_root/config.sh"
+open_mode=$(worktrunk_open_mode)
+
 # Existing local branch → switch (wt creates the worktree if it doesn't exist yet);
 # anything else is a new branch → create it.
 if git show-ref --quiet --verify "refs/heads/$name"; then
-  wtcmd="wt switch \"$name\""
+  wtargs=(switch "$name")
 else
-  wtcmd="wt switch --create \"$name\""
+  wtargs=(switch --create "$name")
 fi
 
-# Open a tab in the workspace the picker was invoked in (--workspace, so it doesn't
-# follow you if you switch away), rooted at the repo, then run wt in its pane.
 herdr=${HERDR_BIN_PATH:-herdr}
-newpane=$("$herdr" tab create --workspace "$HERDR_WORKSPACE_ID" --cwd "$PWD" --label "$name" --focus \
-  | jq -r '.result.root_pane.pane_id')
-[[ -z $newpane ]] && { printf '\033[31m%s\033[0m\n' "failed to open worktree tab"; sleep 2; exit 1; }
 
-# pane run sends the command to the tab's interactive shell; the terminal buffers it
-# until the shell finishes loading, so its `wt` function is in place when it runs.
-"$herdr" pane run "$newpane" "$wtcmd"
+if [[ $open_mode == tab ]]; then
+  # Preserve the original behavior: run wt in a new tab's interactive shell so
+  # shell integration can cd into the worktree and keep the user there.
+  printf -v quoted_name '%q' "$name"
+  if [[ ${wtargs[1]} == --create ]]; then
+    wtcmd="wt switch --create $quoted_name"
+  else
+    wtcmd="wt switch $quoted_name"
+  fi
+
+  newpane=$("$herdr" tab create --workspace "$HERDR_WORKSPACE_ID" --cwd "$PWD" --label "$name" --focus \
+    | jq -r '.result.root_pane.pane_id')
+  [[ -z $newpane ]] && { printf '\033[31m%s\033[0m\n' "failed to open worktree tab"; sleep 2; exit 1; }
+
+  # pane run sends the command to the tab's interactive shell; the terminal buffers it
+  # until the shell finishes loading, so its `wt` function is in place when it runs.
+  "$herdr" pane run "$newpane" "$wtcmd"
+  exit
+fi
+
+# Native workspace mode: let worktrunk create/switch the checkout and run hooks,
+# then register the resulting existing checkout through herdr's worktree API.
+if ! result=$(wt "${wtargs[@]}" --no-cd --format=json); then
+  printf '\n\033[31m%s\033[0m press any key to close' "wt switch failed (see above)."
+  read -n1
+  exit 1
+fi
+
+wtpath=$(printf '%s\n' "$result" | jq -r '.path // empty' 2>/dev/null)
+if [[ -z $wtpath ]]; then
+  wtpath=$(wt list --format=json 2>/dev/null \
+    | jq -r --arg b "$name" '.[] | select(.branch == $b and .kind == "worktree") | .path' \
+    | head -n1)
+fi
+if [[ -z $wtpath ]]; then
+  printf '\033[31m%s\033[0m\n' "worktrunk returned no worktree path for: $name"
+  sleep 2
+  exit 1
+fi
+
+exec "$herdr" worktree open --workspace "$HERDR_WORKSPACE_ID" \
+  --path "$wtpath" --label "$name" --focus --json

--- a/remove.sh
+++ b/remove.sh
@@ -24,8 +24,12 @@ name=$(printf '%s\n' "$cands" \
         --header='↵ to remove (worktrunk will ask to confirm) · esc to cancel')
 [[ -z $name ]] && exit 0      # esc / no selection → cancel
 
-# Path of the worktree we're about to remove, so we can close orphaned panes after.
+# Path and native herdr workspace (if open) of the worktree we're about to remove.
 wtpath=$(printf '%s\n' "$wtjson" | jq -r --arg b "$name" '.[] | select(.branch==$b) | .path')
+wsid=$("$herdr" worktree list --cwd "$PWD" --json 2>/dev/null \
+  | jq -r --arg p "$wtpath" \
+      '.result.worktrees[] | select(.path == $p) | .open_workspace_id // empty' \
+  | head -n1)
 
 # wt remove prompts for approval itself, refuses unmerged branches without -D, and
 # refuses worktrees with untracked files without -f — so run it interactively and let
@@ -35,11 +39,11 @@ if ! wt remove --foreground "$name"; then
   exit 0
 fi
 
-# Close any panes left sitting in the now-deleted worktree (or a subdir of it),
-# except this overlay. Guard against an empty path matching everything.
-# ponytail: matches the pane's shell cwd string; a process that cd'd elsewhere
-# under a still-open shell won't be caught — fine for the common shell-in-worktree case.
-if [[ -n $wtpath && $wtpath != "/" ]]; then
+# Close a native worktree workspace as a unit. Fall back to pane cleanup for the
+# original tab-based mode and worktrees opened by older plugin versions.
+if [[ -n $wsid ]]; then
+  "$herdr" workspace close "$wsid"
+elif [[ -n $wtpath && $wtpath != "/" ]]; then
   "$herdr" pane list 2>/dev/null \
     | jq -r --arg p "$wtpath" --arg self "${HERDR_PANE_ID:-}" \
         '.result.panes[] | select(.pane_id != $self)

--- a/tests/config_test.sh
+++ b/tests/config_test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+# shellcheck source=../config.sh
+source "$repo_root/config.sh"
+
+assert_mode() {
+  local expected=$1 actual
+  actual=$(worktrunk_open_mode 2>/dev/null)
+  if [[ $actual != "$expected" ]]; then
+    printf 'expected mode %q, got %q\n' "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+unset HERDR_PLUGIN_CONFIG_DIR
+assert_mode tab
+
+config_dir=$(mktemp -d)
+trap 'rm -rf "$config_dir"' EXIT
+export HERDR_PLUGIN_CONFIG_DIR=$config_dir
+
+assert_mode tab
+
+printf 'open_mode = "workspace"\n' > "$config_dir/config.toml"
+assert_mode workspace
+
+printf 'open_mode = "tab" # keep the original presentation\n' > "$config_dir/config.toml"
+assert_mode tab
+
+printf 'open_mode = "unsupported"\n' > "$config_dir/config.toml"
+assert_mode tab
+
+printf 'config tests passed\n'

--- a/tests/config_test.sh
+++ b/tests/config_test.sh
@@ -15,21 +15,21 @@ assert_mode() {
 }
 
 unset HERDR_PLUGIN_CONFIG_DIR
-assert_mode tab
+assert_mode workspace
 
 config_dir=$(mktemp -d)
 trap 'rm -rf "$config_dir"' EXIT
 export HERDR_PLUGIN_CONFIG_DIR=$config_dir
 
-assert_mode tab
-
-printf 'open_mode = "workspace"\n' > "$config_dir/config.toml"
 assert_mode workspace
 
-printf 'open_mode = "tab" # keep the original presentation\n' > "$config_dir/config.toml"
+printf 'open_mode = "tab"\n' > "$config_dir/config.toml"
 assert_mode tab
 
+printf 'open_mode = "workspace" # native worktree workspace\n' > "$config_dir/config.toml"
+assert_mode workspace
+
 printf 'open_mode = "unsupported"\n' > "$config_dir/config.toml"
-assert_mode tab
+assert_mode workspace
 
 printf 'config tests passed\n'


### PR DESCRIPTION
## Summary

- keep the original tab-based workflow as the backward-compatible default
- add an `open_mode = "workspace"` option in the managed plugin config
- register Worktrunk checkouts through `herdr worktree open` in workspace mode
- close native worktree workspaces cleanly after Worktrunk removal
- document both modes and add config parser tests

## Why

Opening Worktrunk checkouts through Herdr's native worktree API keeps them organized under their repository in the sidebar. This makes working with multiple worktrees more convenient and consistent with how worktrees are laid out throughout the Herdr system, while preserving Worktrunk lifecycle hooks.

## Testing

- `bash -n config.sh picker.sh remove.sh tests/config_test.sh`
- `bash tests/config_test.sh`
- verified the default mode still issues the original tab and pane commands
- exercised workspace mode against an existing checkout and verified Herdr returned `is_linked_worktree: true`
