### PR TITLE
Support Worktrunk list JSON schema 2

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -19,3 +19,25 @@ worktrunk_ref_exists() {
   git show-ref --quiet --verify "refs/heads/$1" \
     || git show-ref --quiet --verify "refs/remotes/$1"
 }
+
+# Emit one worktrunk list item per line with the schema 1 location fields
+# (`kind`, `path`, and `is_main`) available at the top level. Worktrunk's JSON
+# schema 2 wraps items in an envelope and nests those fields under `worktree`.
+worktrunk_list_items() {
+  jq -c '
+    def normalize:
+      . + {
+        kind: (.kind // (if (.worktree | type) == "object" then "worktree" else "branch" end)),
+        path: (.path // .worktree.path // null),
+        is_main: (.is_main // .worktree.main // false)
+      };
+
+    if type == "array" then
+      .[] | normalize
+    elif type == "object" and ((.items | type) == "array") then
+      .items[] | normalize
+    else
+      error("unsupported worktrunk list JSON schema")
+    end
+  '
+}

--- a/picker.sh
+++ b/picker.sh
@@ -46,7 +46,8 @@ if command -v fzf >/dev/null; then
   choice=$(
     {
       wt list --format=json 2>/dev/null \
-        | jq -r '.[] | select(.branch != null) | .branch'
+        | worktrunk_list_items \
+        | jq -r 'select(.branch != null) | .branch'
       # Drop origin/HEAD: its short form is bare "origin", so filter on the full
       # refname (refs/remotes/origin/HEAD) instead, then emit the short name.
       git for-each-ref --format='%(refname) %(refname:short)' "${branch_refs[@]}" 2>/dev/null \
@@ -119,7 +120,8 @@ fi
 wtpath=$(printf '%s\n' "$result" | jq -r '.path // empty' 2>/dev/null)
 if [[ -z $wtpath ]]; then
   wtpath=$(wt list --format=json 2>/dev/null \
-    | jq -r --arg b "$name" '.[] | select(.branch == $b and .kind == "worktree") | .path' \
+    | worktrunk_list_items \
+    | jq -r --arg b "$name" 'select(.branch == $b and .kind == "worktree") | .path' \
     | head -n1)
 fi
 if [[ -z $wtpath ]]; then

--- a/remove.sh
+++ b/remove.sh
@@ -7,13 +7,22 @@ if ! command -v fzf >/dev/null; then
   printf '\033[31m%s\033[0m\n' "fzf not found on PATH"; sleep 2; exit 1
 fi
 
+plugin_root=${HERDR_PLUGIN_ROOT:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)}
+# shellcheck source=./helpers.sh
+source "$plugin_root/helpers.sh"
+
 herdr=${HERDR_BIN_PATH:-herdr}
-wtjson=$(wt list --format=json 2>/dev/null)
+if ! wtjson=$(wt list --format=json 2>/dev/null); then
+  printf '\033[31m%s\033[0m\n' "failed to list worktrees"; sleep 2; exit 1
+fi
+if ! wtitems=$(printf '%s\n' "$wtjson" | worktrunk_list_items); then
+  printf '\033[31m%s\033[0m\n' "unsupported worktrunk list output"; sleep 2; exit 1
+fi
 
 # Removable = any real worktree except the main one (the primary checkout can't be
 # removed). The current worktree IS removable — wt switches you back to the root repo.
-cands=$(printf '%s\n' "$wtjson" \
-  | jq -r '.[] | select(.branch != null and .is_main != true) | .branch')
+cands=$(printf '%s\n' "$wtitems" \
+  | jq -r 'select(.kind == "worktree" and .branch != null and .is_main != true) | .branch')
 if [[ -z $cands ]]; then
   printf '\033[33m%s\033[0m\n' "No removable worktrees (only the main worktree exists)."; sleep 2; exit 0
 fi
@@ -25,7 +34,8 @@ name=$(printf '%s\n' "$cands" \
 [[ -z $name ]] && exit 0      # esc / no selection → cancel
 
 # Path and native herdr workspace (if open) of the worktree we're about to remove.
-wtpath=$(printf '%s\n' "$wtjson" | jq -r --arg b "$name" '.[] | select(.branch==$b) | .path')
+wtpath=$(printf '%s\n' "$wtitems" \
+  | jq -r --arg b "$name" 'select(.kind == "worktree" and .branch == $b) | .path')
 wsid=$("$herdr" worktree list --cwd "$PWD" --json 2>/dev/null \
   | jq -r --arg p "$wtpath" \
       '.result.worktrees[] | select(.path == $p) | .open_workspace_id // empty' \

--- a/tests/helpers_test.sh
+++ b/tests/helpers_test.sh
@@ -50,4 +50,36 @@ done
 
 cd - >/dev/null
 
+schema_one='[
+  {"branch":"main","kind":"worktree","path":"/repo","is_main":true},
+  {"branch":"feature","kind":"worktree","path":"/repo.feature","is_main":false},
+  {"branch":"ready","kind":"branch"}
+]'
+schema_two='{
+  "schema":2,
+  "items":[
+    {"branch":"main","worktree":{"path":"/repo","main":true}},
+    {"branch":"feature","worktree":{"path":"/repo.feature","main":false}},
+    {"branch":"ready"}
+  ]
+}'
+expected_items='main|worktree|/repo|true
+feature|worktree|/repo.feature|false
+ready|branch|null|false'
+
+for list_json in "$schema_one" "$schema_two"; do
+  actual_items=$(printf '%s\n' "$list_json" \
+    | worktrunk_list_items \
+    | jq -r '[.branch, .kind, (.path | tostring), (.is_main | tostring)] | join("|")')
+  if [[ $actual_items != "$expected_items" ]]; then
+    printf 'unexpected normalized worktrunk list items:\n%s\n' "$actual_items" >&2
+    exit 1
+  fi
+done
+
+if printf '%s\n' '{"schema":3}' | worktrunk_list_items >/dev/null 2>&1; then
+  printf 'expected unsupported worktrunk list schema to fail\n' >&2
+  exit 1
+fi
+
 printf 'helpers tests passed\n'


### PR DESCRIPTION
## Summary

- normalize Worktrunk list output from both the schema 1 array and schema 2 envelope
- use the normalized rows in the worktree picker, path fallback, and remover
- exclude branch-only rows from the removal picker and report unsupported list output clearly
- add regression coverage proving schemas 1 and 2 normalize identically

## Problem

With Worktrunk JSON schema 2 enabled, `wt list --format=json` returns an envelope containing `.items`, while the plugin indexes the top-level value as an array. The remove action consequently prints a jq error and incorrectly reports that only the main worktree exists. Schema 2 also moves `path` and `main` under `.worktree`.

## Tests

- `bash tests/helpers_test.sh`
- `bash tests/config_test.sh`
- `bash -n helpers.sh remove.sh picker.sh tests/helpers_test.sh tests/config_test.sh`
- verified the helper against real Worktrunk v0.72.0 output with both `list.json-schema=1` and `list.json-schema=2`